### PR TITLE
Run deptrac with many config files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: 🚓 Run test
-        run: for CONF in deptrac.yaml deptrac-*.yaml; do vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
+        run: for CONF in deptrac.yaml deptrac-*.yaml; do test ! -f "$CONF" && continue || vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
 
   security-check:
     name: Vulnerability Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: 🚓 Run test
-        run: vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered
+        run: for CONF in ./deptrac.*; do vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
 
   security-check:
     name: Vulnerability Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: 🚓 Run test
-        run: for CONF in ./deptrac.*; do vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
+        run: for CONF in deptrac.yaml deptrac-*.yaml; do vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
 
   security-check:
     name: Vulnerability Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,10 @@ jobs:
         uses: ramsey/composer-install@v2
 
       - name: 🚓 Run test
-        run: for CONF in deptrac.yaml deptrac-*.yaml; do test ! -f "$CONF" && continue || vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; done
+        run: | 
+          for CONF in deptrac.yaml deptrac-*.yaml; do 
+            test ! -f "$CONF" && continue || vendor/bin/deptrac -v --report-uncovered --fail-on-uncovered --config-file="$CONF"; 
+          done
 
   security-check:
     name: Vulnerability Check


### PR DESCRIPTION
This PR changes the way deptrac is called. It introduces a for loop which calls deptrac with any file matching deptrac.*

It has been successfully tested here: https://github.com/stetind/stem-dev-standards/actions/runs/4882129171/jobs/8711827204