### PR TITLE
chore: disable automated releases

### DIFF
--- a/.github/workflows/generate-release.yaml
+++ b/.github/workflows/generate-release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release - NOT WORKING YET
 
 on:
   workflow_call:
@@ -35,43 +35,43 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
 
-      - name: Calculate Next Semver Version
-        id: semver
-        uses: ietf-tools/semver-action@v1
-        with:
-          token: ${{ github.token }}
-          patchList: fix, bugfix, perf, ref, refactor, test, tests, chore, ci, docs, build
-          noVersionBumpBehavior: current
-
-      - name: Create Draft Release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          allowUpdates: true
-          draft: false
-          prerelease: true
-          commit: ${{ github.sha }}
-          tag: ${{ steps.semver.outputs.nextStrict }}
-          name: ${{ steps.semver.outputs.nextStrict }}
-          body: '*pending...*'
-          token: ${{ github.token }}
-
-      - name: Update CHANGELOG  # he needs tags to work
-        id: changelog
-        uses: requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          tag: ${{ steps.semver.outputs.nextStrict }}
-          writeToFile: false
-          includeInvalidCommits: true
-
-      - name: Create Release ${{ steps.semver.outputs.nextStrict }}
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          allowUpdates: true
-          draft: true
-          prerelease: false
-          makeLatest: true
-          tag: ${{ steps.semver.outputs.nextStrict }}
-          name: ${{ steps.semver.outputs.nextStrict }}
-          body: ${{ steps.changelog.outputs.changes }}
-          token: ${{ github.token }}
+#      - name: Calculate Next Semver Version
+#        id: semver
+#        uses: ietf-tools/semver-action@v1
+#        with:
+#          token: ${{ github.token }}
+#          patchList: fix, bugfix, perf, ref, refactor, test, tests, chore, ci, docs, build
+#          noVersionBumpBehavior: current
+#
+#      - name: Create Draft Release
+#        uses: ncipollo/release-action@v1.12.0
+#        with:
+#          allowUpdates: true
+#          draft: false
+#          prerelease: true
+#          commit: ${{ github.sha }}
+#          tag: ${{ steps.semver.outputs.nextStrict }}
+#          name: ${{ steps.semver.outputs.nextStrict }}
+#          body: '*pending...*'
+#          token: ${{ github.token }}
+#
+#      - name: Update CHANGELOG  # he needs tags to work
+#        id: changelog
+#        uses: requarks/changelog-action@v1
+#        with:
+#          token: ${{ github.token }}
+#          tag: ${{ steps.semver.outputs.nextStrict }}
+#          writeToFile: false
+#          includeInvalidCommits: true
+#
+#      - name: Create Release ${{ steps.semver.outputs.nextStrict }}
+#        uses: ncipollo/release-action@v1.12.0
+#        with:
+#          allowUpdates: true
+#          draft: true
+#          prerelease: false
+#          makeLatest: true
+#          tag: ${{ steps.semver.outputs.nextStrict }}
+#          name: ${{ steps.semver.outputs.nextStrict }}
+#          body: ${{ steps.changelog.outputs.changes }}
+#          token: ${{ github.token }}


### PR DESCRIPTION
Disable programmaticaly, automated releases, as due to actions limitation they need an existing tag in order to produce release description. 
In contradiction, this tag  falsely , seems like a valid release   

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206384071329041